### PR TITLE
Set key frame

### DIFF
--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -303,15 +303,27 @@ namespace laser_odometry
 
     /**
      * @brief Get the referent LaserScan.
-     * @param[in]
+     * @param[in] the sensor_msgs::LaserScan key-frame.
      */
     void getKeyFrame(sensor_msgs::LaserScanConstPtr& kframe) const noexcept;
 
     /**
+     * @brief Set the referent LaserScan.
+     * @param[in] the sensor_msgs::LaserScan key-frame.
+     */
+    void setKeyFrame(const sensor_msgs::LaserScanConstPtr& kframe);
+
+    /**
      * @brief Get the referent PointCloud2.
-     * @param[in]
+     * @param[in] the sensor_msgs::PointCloud2 key-frame.
      */
     void getKeyFrame(sensor_msgs::PointCloud2ConstPtr& kframe) const noexcept;
+
+    /**
+     * @brief Set the referent PointCloud2.
+     * @param[in] the sensor_msgs::PointCloud2 key-frame.
+     */
+    void setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& kframe);
 
   protected:
 

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -305,25 +305,25 @@ namespace laser_odometry
      * @brief Get the referent LaserScan.
      * @param[in] the sensor_msgs::LaserScan key-frame.
      */
-    void getKeyFrame(sensor_msgs::LaserScanConstPtr& kframe) const noexcept;
+    void getKeyFrame(sensor_msgs::LaserScanConstPtr& key_frame_msg) const noexcept;
 
     /**
      * @brief Set the referent LaserScan.
      * @param[in] the sensor_msgs::LaserScan key-frame.
      */
-    void setKeyFrame(const sensor_msgs::LaserScanConstPtr& kframe);
+    void setKeyFrame(const sensor_msgs::LaserScanConstPtr& key_frame_msg);
 
     /**
      * @brief Get the referent PointCloud2.
      * @param[in] the sensor_msgs::PointCloud2 key-frame.
      */
-    void getKeyFrame(sensor_msgs::PointCloud2ConstPtr& kframe) const noexcept;
+    void getKeyFrame(sensor_msgs::PointCloud2ConstPtr& key_frame_msg) const noexcept;
 
     /**
      * @brief Set the referent PointCloud2.
      * @param[in] the sensor_msgs::PointCloud2 key-frame.
      */
-    void setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& kframe);
+    void setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& key_frame_msg);
 
   protected:
 

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_instantiater.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_instantiater.h
@@ -71,7 +71,7 @@ namespace detail
 using Instantiater = details::Singleton<LaserOdometryInstantiater>;
 }
 
-LaserOdometryPtr make_laser_odometry(const std::string& laser_odometry_type)
+inline LaserOdometryPtr make_laser_odometry(const std::string& laser_odometry_type)
 {
   return detail::Instantiater::get().instantiate_impl(laser_odometry_type);
 }

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
@@ -29,6 +29,8 @@ bool getTf(const tf::tfMessagePtr tf_msg,
            const std::string& target_frame,
            tf::Transform& tf);
 
+bool isIdentity(const tf::Transform& tf, const double eps = 1e-8);
+
 std::string format(const tf::Transform& tf);
 
 void print(const tf::Transform& tf, const std::string& h = "");

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
@@ -29,7 +29,7 @@ bool getTf(const tf::tfMessagePtr tf_msg,
            const std::string& target_frame,
            tf::Transform& tf);
 
-std::string format(const tf::Transform& tf, const std::string& h = "");
+std::string format(const tf::Transform& tf);
 
 void print(const tf::Transform& tf, const std::string& h = "");
 

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -341,6 +341,36 @@ bool LaserOdometryBase::hasNewKeyFrame() const noexcept
   return has_new_kf_;
 }
 
+void LaserOdometryBase::setKeyFrame(const sensor_msgs::LaserScanConstPtr& kframe)
+{
+  initialized_ = initialize(kframe);
+
+  fixed_origin_to_base_ = fixed_origin_ * fixed_to_base_;
+
+  //pose_covariance_ = twist_covariance_;
+
+  ROS_INFO_STREAM_COND(initialized_, "LaserOdometry Initialized!");
+
+  /// @todo since we're setting the key-frame
+  /// we probably should reset some transforms
+  reference_scan_ = kframe;
+}
+
+void LaserOdometryBase::setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& kframe)
+{
+  initialized_ = initialize(kframe);
+
+  fixed_origin_to_base_ = fixed_origin_ * fixed_to_base_;
+
+  //pose_covariance_ = twist_covariance_;
+
+  ROS_INFO_STREAM_COND(initialized_, "LaserOdometry Initialized!");
+
+  /// @todo since we're setting the key-frame
+  /// we probably should reset some transforms
+  reference_cloud_ = kframe;
+}
+
 void LaserOdometryBase::getKeyFrame(sensor_msgs::LaserScanConstPtr& kframe) const noexcept
 {
   kframe = reference_scan_;

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -76,14 +76,27 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg,
 
   preProcessing();
 
-  tf::Transform guess_relative_tf_ = predict(relative_tf_);
+  tf::Transform guess_relative_tf;
+
+  // If an increment prior has been set, use it.
+  // Otherwise predict from previously
+  // computed relative_tf_
+  if (utils::isIdentity(guess_relative_tf_))
+  {
+    guess_relative_tf  = guess_relative_tf_;
+    guess_relative_tf_ = tf::Transform::getIdentity();
+  }
+  else
+  {
+    guess_relative_tf = predict(relative_tf_);
+  }
 
   // account for the change since the last kf, in the fixed frame
-  guess_relative_tf_ = guess_relative_tf_ * (fixed_to_base_ * fixed_to_base_kf_.inverse());
+  guess_relative_tf = guess_relative_tf * (fixed_to_base_ * fixed_to_base_kf_.inverse());
 
   // the predicted change of the laser's position, in the laser frame
   tf::Transform pred_rel_tf_in_ltf = laser_to_base_ * fixed_to_base_.inverse() *
-                                      guess_relative_tf_ * fixed_to_base_ * base_to_laser_ ;
+                                      guess_relative_tf * fixed_to_base_ * base_to_laser_;
 
   // The actual computation
   const bool processed = process_impl(scan_msg, pred_rel_tf_in_ltf);
@@ -177,14 +190,27 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
 
   preProcessing();
 
-  tf::Transform guess_relative_tf_ = predict(relative_tf_);
+  tf::Transform guess_relative_tf;
+
+  // If an increment prior has been set, use it.
+  // Otherwise predict from previously
+  // computed relative_tf_
+  if (utils::isIdentity(guess_relative_tf_))
+  {
+    guess_relative_tf  = guess_relative_tf_;
+    guess_relative_tf_ = tf::Transform::getIdentity();
+  }
+  else
+  {
+    guess_relative_tf = predict(relative_tf_);
+  }
 
   // account for the change since the last kf, in the fixed frame
-  guess_relative_tf_ = guess_relative_tf_ * (fixed_to_base_ * fixed_to_base_kf_.inverse());
+  guess_relative_tf = guess_relative_tf * (fixed_to_base_ * fixed_to_base_kf_.inverse());
 
   // the predicted change of the laser's position, in the laser frame
   tf::Transform pred_rel_tf_in_ltf = laser_to_base_ * fixed_to_base_.inverse() *
-                                      guess_relative_tf_ * fixed_to_base_ * base_to_laser_ ;
+                                      guess_relative_tf * fixed_to_base_ * base_to_laser_ ;
 
   // The actual computation
   const bool processed = process_impl(cloud_msg, pred_rel_tf_in_ltf);

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -78,7 +78,7 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg,
 
   tf::Transform guess_relative_tf;
 
-  // If an increment prior has been set, use it.
+  // If an increment prior has been set, 'consum' it.
   // Otherwise predict from previously
   // computed relative_tf_
   if (utils::isIdentity(guess_relative_tf_))
@@ -192,7 +192,7 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
 
   tf::Transform guess_relative_tf;
 
-  // If an increment prior has been set, use it.
+  // If an increment prior has been set, 'consum' it.
   // Otherwise predict from previously
   // computed relative_tf_
   if (utils::isIdentity(guess_relative_tf_))

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -52,7 +52,7 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg,
                            geometry_msgs::Pose2DPtr pose_increment_msg)
 {
   assert_not_null(scan_msg);
-  assert_not_null(pose_msg);
+//  assert_not_null(pose_msg);
 
   has_new_kf_   = false;
   current_time_ = scan_msg->header.stamp;
@@ -110,6 +110,7 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg,
   fillIncrementMsg(pose_increment_msg);
 
   has_new_kf_ = isKeyFrame(relative_tf_);
+
   if (has_new_kf_)
   {
     // generate a keyframe
@@ -134,7 +135,7 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_ptr,
                            nav_msgs::OdometryPtr odom_increment_msg)
 {
   assert_not_null(scan_ptr);
-  assert_not_null(odom_ptr);
+//  assert_not_null(odom_ptr);
 
   geometry_msgs::Pose2DPtr pose_2d_ptr = boost::make_shared<geometry_msgs::Pose2D>();
 
@@ -152,7 +153,7 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
                            geometry_msgs::Pose2DPtr pose_increment_msg)
 {
   assert_not_null(cloud_msg);
-  assert_not_null(pose_msg);
+//  assert_not_null(pose_msg);
 
   has_new_kf_   = false;
   current_time_ = cloud_msg->header.stamp;
@@ -234,8 +235,7 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
                            nav_msgs::OdometryPtr odom_increment_msg)
 {
   assert_not_null(cloud_msg);
-  assert_not_null(odom_ptr);
-  assert_not_null(odom_ptr);
+//  assert_not_null(odom_ptr);
 
   geometry_msgs::Pose2DPtr pose_2d_ptr = boost::make_shared<geometry_msgs::Pose2D>();
 

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -52,7 +52,6 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg,
                            geometry_msgs::Pose2DPtr pose_increment_msg)
 {
   assert_not_null(scan_msg);
-//  assert_not_null(pose_msg);
 
   has_new_kf_   = false;
   current_time_ = scan_msg->header.stamp;
@@ -148,7 +147,6 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_ptr,
                            nav_msgs::OdometryPtr odom_increment_msg)
 {
   assert_not_null(scan_ptr);
-//  assert_not_null(odom_ptr);
 
   geometry_msgs::Pose2DPtr pose_2d_ptr = boost::make_shared<geometry_msgs::Pose2D>();
 
@@ -166,7 +164,6 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
                            geometry_msgs::Pose2DPtr pose_increment_msg)
 {
   assert_not_null(cloud_msg);
-//  assert_not_null(pose_msg);
 
   has_new_kf_   = false;
   current_time_ = cloud_msg->header.stamp;
@@ -261,7 +258,6 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
                            nav_msgs::OdometryPtr odom_increment_msg)
 {
   assert_not_null(cloud_msg);
-//  assert_not_null(odom_ptr);
 
   geometry_msgs::Pose2DPtr pose_2d_ptr = boost::make_shared<geometry_msgs::Pose2D>();
 
@@ -367,9 +363,11 @@ bool LaserOdometryBase::hasNewKeyFrame() const noexcept
   return has_new_kf_;
 }
 
-void LaserOdometryBase::setKeyFrame(const sensor_msgs::LaserScanConstPtr& kframe)
+void LaserOdometryBase::setKeyFrame(const sensor_msgs::LaserScanConstPtr& key_frame_msg)
 {
-  initialized_ = initialize(kframe);
+  assert_not_null(key_frame_msg);
+
+  initialized_ = initialize(key_frame_msg);
 
   fixed_origin_to_base_ = fixed_origin_ * fixed_to_base_;
 
@@ -379,12 +377,14 @@ void LaserOdometryBase::setKeyFrame(const sensor_msgs::LaserScanConstPtr& kframe
 
   /// @todo since we're setting the key-frame
   /// we probably should reset some transforms
-  reference_scan_ = kframe;
+  reference_scan_ = key_frame_msg;
 }
 
-void LaserOdometryBase::setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& kframe)
+void LaserOdometryBase::setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& key_frame_msg)
 {
-  initialized_ = initialize(kframe);
+  assert_not_null(key_frame_msg);
+
+  initialized_ = initialize(key_frame_msg);
 
   fixed_origin_to_base_ = fixed_origin_ * fixed_to_base_;
 
@@ -394,17 +394,17 @@ void LaserOdometryBase::setKeyFrame(const sensor_msgs::PointCloud2ConstPtr& kfra
 
   /// @todo since we're setting the key-frame
   /// we probably should reset some transforms
-  reference_cloud_ = kframe;
+  reference_cloud_ = key_frame_msg;
 }
 
-void LaserOdometryBase::getKeyFrame(sensor_msgs::LaserScanConstPtr& kframe) const noexcept
+void LaserOdometryBase::getKeyFrame(sensor_msgs::LaserScanConstPtr& key_frame_msg) const noexcept
 {
-  kframe = reference_scan_;
+  key_frame_msg = reference_scan_;
 }
 
-void LaserOdometryBase::getKeyFrame(sensor_msgs::PointCloud2ConstPtr& kframe) const noexcept
+void LaserOdometryBase::getKeyFrame(sensor_msgs::PointCloud2ConstPtr& key_frame_msg) const noexcept
 {
-  kframe = reference_cloud_;
+  key_frame_msg = reference_cloud_;
 }
 
 ////////////////////////

--- a/laser_odometry_core/src/laser_odometry_utils.cpp
+++ b/laser_odometry_core/src/laser_odometry_utils.cpp
@@ -71,13 +71,12 @@ bool getTf(const tf::tfMessagePtr tf_msg,
   return false;
 }
 
-std::string format(const tf::Transform& tf, const std::string& h)
+std::string format(const tf::Transform& tf)
 {
   std::stringstream ss;
 
-  ss << h
-     << tf.getOrigin().getX()
-     << " " << tf.getOrigin().getX()
+  ss << tf.getOrigin().getX()
+     << " " << tf.getOrigin().getY()
      << " " << tf::getYaw(tf.getRotation());
 
   return ss.str();
@@ -85,7 +84,7 @@ std::string format(const tf::Transform& tf, const std::string& h)
 
 void print(const tf::Transform& tf, const std::string& h)
 {
-  std::cout << format(tf) << std::endl;
+  std::cout << h << format(tf) << std::endl;
 }
 
 } /* namespace utils */

--- a/laser_odometry_core/src/laser_odometry_utils.cpp
+++ b/laser_odometry_core/src/laser_odometry_utils.cpp
@@ -71,6 +71,20 @@ bool getTf(const tf::tfMessagePtr tf_msg,
   return false;
 }
 
+bool isIdentity(const tf::Transform& tf, const double eps)
+{
+  const tf::Vector3& o = tf.getOrigin();
+
+  if (o.x() > eps) return false;
+  if (o.y() > eps) return false;
+  if (o.z() > eps) return false;
+
+  if (tf.getRotation().angleShortestPath(
+        tf::Quaternion::getIdentity()) > eps) return false;
+
+  return true;
+}
+
 std::string format(const tf::Transform& tf)
 {
   std::stringstream ss;


### PR DESCRIPTION
Add `setKeyFrame` for user defined key-frame (e.g. plain scan-matching).

Use user defined increment prior if different than identity. Otherwise use `predict()`.