### PR TITLE
Explicit frame renaming

### DIFF
--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -61,7 +61,7 @@ namespace laser_odometry
    *          return |
    *                 \  predict   otherwise         [O]
    *
-   *       - process_impl                           [X]
+   *       - processImpl                            [X]
    *
    *       - posePlusIncrement                      [X]
    *
@@ -165,8 +165,8 @@ namespace laser_odometry
      *
      * @note [Necessary] To be implemented in the derived class.
      */
-    virtual bool process_impl(const sensor_msgs::LaserScanConstPtr& laser_msg,
-                              const Transform& prediction);
+    virtual bool processImpl(const sensor_msgs::LaserScanConstPtr& laser_msg,
+                             const Transform& prediction);
 
     /**
      * @brief Function to be implemented by the derived plugin.
@@ -179,8 +179,8 @@ namespace laser_odometry
      *
      * @note [Necessary] To be implemented in the derived class.
      */
-    virtual bool process_impl(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
-                              const Transform& prediction);
+    virtual bool processImpl(const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
+                             const Transform& prediction);
 
   public:
 

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -394,8 +394,8 @@ namespace laser_odometry
     /// @note This is the transform the derived class should fills.
     Transform increment_ = Transform::Identity();
 
-    /// @brief The relative transform in the base_frame.
-    Transform relative_tf_ = Transform::Identity();
+    /// @brief The increment in the base_frame.
+    Transform increment_in_base_ = Transform::Identity();
 
     /// @brief Guessed/predicted tranform
     /// from reference_'reading' to
@@ -405,12 +405,12 @@ namespace laser_odometry
     /// @brief Tranform from fixed_frame
     /// to base_frame, where fixed_frame
     /// is the origin of the integration.
-    /// == fixed_to_base_kf_ * relative_tf_.
+    /// == fixed_to_base_kf_ * increment_in_base_.
     Transform fixed_to_base_ = Transform::Identity();
 
     /// @brief Tranform from fixed_frame to
     /// the last keyfame frame.
-    /// == fixed_to_base * relative_tf_.
+    /// == fixed_to_base * increment_in_base_.
     Transform fixed_to_base_kf_ = Transform::Identity();
 
     /// @brief An optional user defined

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -235,24 +235,26 @@ namespace laser_odometry
     void setOrigin(const Transform& origin);
 
     /**
-     * @brief Const-reference to the initial prediction transform of the upcoming matching.
-     * It is the pose increment from the last processed scan
-     * to the current one.
-     * @return Const-reference to the initial prediction transform of the upcoming matching.
+     * @brief Const-reference to the increment prior in the base_frame
+     * of the upcoming matching.
+     * It is the prior of the pose increment in the base_frame
+     * from the last processed scan to the current one.
+     * @return Const-reference to the increment prior of the upcoming matching.
      */
-    const Transform& getInitialGuess() const;
+    const Transform& getIncrementPrior() const;
 
     /**
-     * @brief Set the initial prediction of the upcoming matching.
-     * It is the pose increment from the last processed scan
-     * to the current one.
-     * @param[in] guess. The initial prediciton.
+     * @brief Set the increment prior in the base_frame
+     * of the upcoming matching.
+     * It is the prior of the pose increment in the base_frame
+     * from the last processed scan to the current one.
+     * @param[in] guess. The increment prior of the upcoming matching.
      */
-    void setInitialGuess(const Transform& guess);
+    void setIncrementPrior(const Transform& increment_in_base_prior);
 
     /**
-     * @brief Const-reference to the laser pose wrt the robot base frame.
-     * @return Const-reference to the laser pose wrt the robot base frame.
+     * @brief Const-reference to the laser pose wrt the robot base_frame.
+     * @return Const-reference to the laser pose wrt the robot base_frame.
      */
     const Transform& getLaserPose() const;
 
@@ -398,7 +400,7 @@ namespace laser_odometry
     /// @brief Guessed/predicted tranform
     /// from reference_'reading' to
     /// current_'reading' in the base_frame.
-    Transform guess_relative_tf_ = Transform::Identity();
+    Transform increment_in_base_prior_ = Transform::Identity();
 
     /// @brief Tranform from fixed_frame
     /// to base_frame, where fixed_frame

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -56,8 +56,8 @@ namespace laser_odometry
    *
    *       - getIncrementPrior
    *
-   *                    guess_relative_tf_ *IF*
-   *                 /  set using setInitialGuess
+   *                    increment_in_laser_prior_ *IF*
+   *                 /  set using setIncrementPrior
    *          return |
    *                 \  predict   otherwise         [O]
    *
@@ -483,14 +483,26 @@ namespace laser_odometry
     virtual void preProcessing();
 
     /**
-     * @brief getIncrementPrior. Return the increment prior
-     * either set by user if set (default) or using predict.
-     * @return The increment prior.
+     * @brief getIncrementPriorInKeyFrame. Return the increment prior
+     * in the last key-frame frame by using either the increment_in_base_prior_
+     * set by user (if set) (default) or using predict().
+     * @return The increment prior in the last key-frame frame.
      *
-     * @see setInitialGuess
+     * @see setIncrementPrior
      * @see predict
      */
-    Transform getIncrementPrior();
+    Transform getIncrementPriorInKeyFrame();
+
+    /**
+     * @brief getIncrementPriorInLaserFrame. Return the increment prior
+     * taking into acount the last key-frame in the laser frame.
+     * @return The increment prior in the last laser frame.
+     *
+     * @see getIncrementPriorInKeyFrame
+     * @see setIncrementPrior
+     * @see predict
+     */
+    Transform getIncrementPriorInLaserFrame();
 
     /**
      * @brief posePlusIncrement. Update the estimated current pose

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -223,12 +223,6 @@ namespace laser_odometry
     /* Guetter / Setter */
 
     /**
-     * @brief Reference to the origin frame.
-     * @return Reference to the origin frame.
-     */
-    Transform& getOrigin();
-
-    /**
      * @brief Const-reference to the origin frame.
      * @return Const-reference to the origin frame.
      */
@@ -239,14 +233,6 @@ namespace laser_odometry
      * @param[in] origin. The origin frame.
      */
     void setOrigin(const Transform& origin);
-
-    /**
-     * @brief Reference to the initial prediction transform of the upcoming matching.
-     * It is the pose increment from the last processed scan
-     * to the current one.
-     * @return Reference to the initial prediction transform of the upcoming matching.
-     */
-    Transform& getInitialGuess();
 
     /**
      * @brief Const-reference to the initial prediction transform of the upcoming matching.
@@ -263,12 +249,6 @@ namespace laser_odometry
      * @param[in] guess. The initial prediciton.
      */
     void setInitialGuess(const Transform& guess);
-
-    /**
-     * @brief Reference to the laser pose wrt the robot base frame.
-     * @return Reference to the laser pose wrt the robot base frame.
-     */
-    Transform& getLaserPose();
 
     /**
      * @brief Const-reference to the laser pose wrt the robot base frame.

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -56,10 +56,10 @@ namespace laser_odometry
    *
    *       - getIncrementPrior
    *
-   *                    increment_in_laser_prior_ *IF*
+   *                    increment_in_base_prior_ *IF*
    *                 /  set using setIncrementPrior
    *          return |
-   *                 \  predict   otherwise         [O]
+   *                 \  predict()  otherwise        [O]
    *
    *       - processImpl                            [X]
    *
@@ -521,8 +521,8 @@ namespace laser_odometry
 
     /**
      * @brief Evaluate if the current reading should become the new
-     * referent reading form the matching.
-     * @param[in] The estimated pose increment in the world_frame_ frame.
+     * referent reading for the matching.
+     * @param[in] The estimated pose increment in the base_frame_ frame.
      * @return Whether the currently evaluated reading is the new referent.
      *
      * @note The base class returns \b true by default.

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -188,7 +188,7 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg)
   const Transform pred_rel_tf_in_ltf = laser_to_base_ * getIncrementPrior() * base_to_laser_;
 
   // The actual computation
-  const bool processed = process_impl(scan_msg, pred_rel_tf_in_ltf);
+  const bool processed = processImpl(scan_msg, pred_rel_tf_in_ltf);
 
   posePlusIncrement(processed);
 
@@ -241,7 +241,7 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg)
   const Transform pred_rel_tf_in_ltf = laser_to_base_ * getIncrementPrior() * base_to_laser_;
 
   // The actual computation
-  const bool processed = process_impl(cloud_msg, pred_rel_tf_in_ltf);
+  const bool processed = processImpl(cloud_msg, pred_rel_tf_in_ltf);
 
   posePlusIncrement(processed);
 
@@ -265,16 +265,16 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg)
   return ProcessReport{processed, has_new_kf_};
 }
 
-bool LaserOdometryBase::process_impl(const sensor_msgs::LaserScanConstPtr& /*laser_msg*/,
-                                     const Transform& /*prediction*/)
+bool LaserOdometryBase::processImpl(const sensor_msgs::LaserScanConstPtr& /*laser_msg*/,
+                                    const Transform& /*prediction*/)
 {
-  throw std::runtime_error("process_impl(sensor_msgs::LaserScanConstPtr) not implemented.");
+  throw std::runtime_error("processImpl(sensor_msgs::LaserScanConstPtr) not implemented.");
 }
 
-bool LaserOdometryBase::process_impl(const sensor_msgs::PointCloud2ConstPtr& /*cloud_msg*/,
-                                     const Transform& /*prediction*/)
+bool LaserOdometryBase::processImpl(const sensor_msgs::PointCloud2ConstPtr& /*cloud_msg*/,
+                                    const Transform& /*prediction*/)
 {
-  throw std::runtime_error("process_impl(sensor_msgs::PointCloud2ConstPtr) not implemented.");
+  throw std::runtime_error("processImpl(sensor_msgs::PointCloud2ConstPtr) not implemented.");
 }
 
 Transform LaserOdometryBase::getIncrementPrior()

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -500,11 +500,6 @@ void LaserOdometryBase::getKeyFrame(sensor_msgs::PointCloud2ConstPtr& key_frame_
   key_frame_msg = reference_cloud_;
 }
 
-Transform& LaserOdometryBase::getOrigin()
-{
-  return fixed_origin_;
-}
-
 const Transform& LaserOdometryBase::getOrigin() const
 {
   return fixed_origin_;
@@ -524,11 +519,6 @@ void LaserOdometryBase::setOrigin(const Transform& origin)
   }
 }
 
-Transform& LaserOdometryBase::getInitialGuess()
-{
-  return guess_relative_tf_;
-}
-
 const Transform& LaserOdometryBase::getInitialGuess() const
 {
   return guess_relative_tf_;
@@ -546,11 +536,6 @@ void LaserOdometryBase::setInitialGuess(const Transform& guess)
               " is not orthogonal.\nSetting Identity instead.");
     guess_relative_tf_ = Transform::Identity();
   }
-}
-
-Transform& LaserOdometryBase::getLaserPose()
-{
-  return base_to_laser_;
 }
 
 const Transform& LaserOdometryBase::getLaserPose() const

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -182,13 +182,10 @@ LaserOdometryBase::process(const sensor_msgs::LaserScanConstPtr& scan_msg)
   preProcessing();
 
   // the predicted change of the laser's position, in the laser frame
-//  const Transform pred_rel_tf_in_ltf = laser_to_base_ * fixed_to_base_.inverse() *
-//                                        incrementPrior() * fixed_to_base_ * base_to_laser_;
-
-  const Transform pred_rel_tf_in_ltf = laser_to_base_ * getIncrementPrior() * base_to_laser_;
+  const Transform increment_prior_in_laser = getIncrementPriorInLaserFrame();
 
   // The actual computation
-  const bool processed = processImpl(scan_msg, pred_rel_tf_in_ltf);
+  const bool processed = processImpl(scan_msg, increment_prior_in_laser);
 
   posePlusIncrement(processed);
 
@@ -235,13 +232,10 @@ LaserOdometryBase::process(const sensor_msgs::PointCloud2ConstPtr& cloud_msg)
   preProcessing();
 
   // the predicted change of the laser's position, in the laser frame
-//  const Transform pred_rel_tf_in_ltf = laser_to_base_ * fixed_to_base_.inverse() *
-//                                        incrementPrior() * fixed_to_base_ * base_to_laser_;
-
-  const Transform pred_rel_tf_in_ltf = laser_to_base_ * getIncrementPrior() * base_to_laser_;
+  const Transform increment_prior_in_laser = getIncrementPriorInLaserFrame();
 
   // The actual computation
-  const bool processed = processImpl(cloud_msg, pred_rel_tf_in_ltf);
+  const bool processed = processImpl(cloud_msg, increment_prior_in_laser);
 
   posePlusIncrement(processed);
 
@@ -277,7 +271,7 @@ bool LaserOdometryBase::processImpl(const sensor_msgs::PointCloud2ConstPtr& /*cl
   throw std::runtime_error("processImpl(sensor_msgs::PointCloud2ConstPtr) not implemented.");
 }
 
-Transform LaserOdometryBase::getIncrementPrior()
+Transform LaserOdometryBase::getIncrementPriorInKeyFrame()
 {
   Transform increment_in_base_prior = Transform::Identity();
 
@@ -306,8 +300,12 @@ Transform LaserOdometryBase::getIncrementPrior()
   return increment_in_base_prior;
 }
 
+Transform LaserOdometryBase::getIncrementPriorInLaserFrame()
+{
+  return laser_to_base_ * getIncrementPriorInKeyFrame() * base_to_laser_;
 
-  return guess_relative_tf;
+//  return laser_to_base_ * fixed_to_base_.inverse() *
+//          incrementPrior() * fixed_to_base_ * base_to_laser_;
 }
 
 void LaserOdometryBase::posePlusIncrement(const bool processed)


### PR DESCRIPTION
- Renamed `process_impl` -> `processImpl`
- Removed some useless `get*` by reference
- Renaming some frame's variables with more explicit names