### PR TITLE
Process template

### DIFF
--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -12,6 +12,33 @@
 
 namespace laser_odometry
 {
+namespace utils
+{
+template<typename T>
+void getParam(const ros::NodeHandle& nh, const std::string& param_name,
+              T& param_val, const T& default_val, const bool verbose)
+{
+  if (nh.hasParam(param_name))
+  {
+    if (nh.getParam(param_name, param_val))
+    {
+      return;
+    }
+    else
+      ROS_WARN_STREAM_COND(verbose, "Could not retrieve param " << param_name);
+  }
+  else
+    ROS_WARN_STREAM_COND(verbose, "Param " << param_name
+                         << " does not exist on the param server.");
+
+  ROS_WARN_STREAM_COND(verbose, "Setting default value for param " << param_name);
+  param_val = default_val;
+}
+} /* namespace utils */
+} /* namespace laser_odometry */
+
+namespace laser_odometry
+{
   using TransformWithCovariancePtr = boost::shared_ptr<TransformWithCovariance>;
 
   /**

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -120,12 +120,20 @@ namespace laser_odometry
     /**
      * @brief Default constructor.
      */
-    LaserOdometryBase()          = default;
+    LaserOdometryBase() = default;
 
     /**
      * @brief Default destructor.
      */
     virtual ~LaserOdometryBase() = default;
+
+    // non construction-copyable/movable
+    LaserOdometryBase(const LaserOdometryBase&) = delete;
+    LaserOdometryBase(LaserOdometryBase&&)      = delete;
+
+    // non copyable/movable
+    LaserOdometryBase& operator=(const LaserOdometryBase&) = delete;
+    LaserOdometryBase& operator=(LaserOdometryBase&&)      = delete;
 
     /**
      * @brief Compute the 2D odometry given a sensor_msgs::LaserScan.
@@ -473,9 +481,9 @@ namespace laser_odometry
 
     ros::NodeHandle private_nh_ = ros::NodeHandle("~");
 
-    std::string base_frame_       = "base_link";        /// @brief The robot base frame name.
-    std::string laser_frame_      = "base_laser_link";  /// @brief The robot laser frame name.
-    std::string fixed_frame_      = "map";              /// @brief The global fixed frame name.
+    std::string base_frame_  = "base_link";        /// @brief The robot base frame name.
+    std::string laser_frame_ = "base_laser_link";  /// @brief The robot laser frame name.
+    std::string fixed_frame_ = "map";              /// @brief The global fixed frame name.
 
     /// @brief The global odometry frame name.
     /// This frame name is only used in the published message.

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.h
@@ -704,11 +704,7 @@ namespace laser_odometry
      * and the estimated pose increment.
      */
     template <typename PoseMsgT, typename IncrementMsgT>
-    void fillMsgs(PoseMsgT&& pose_msg_ptr, IncrementMsgT&& increment_msg_ptr)
-    {
-      fillMsg(std::forward<PoseMsgT>(pose_msg_ptr));
-      fillIncrementMsg(std::forward<IncrementMsgT>(increment_msg_ptr));
-    }
+    void fillMsgs(PoseMsgT&& pose_msg_ptr, IncrementMsgT&& increment_msg_ptr);
   };
 
   /// @brief A base-class pointer.
@@ -717,92 +713,6 @@ namespace laser_odometry
 } /* namespace laser_odometry */
 
 #include <laser_odometry_core/laser_odometry_report.h>
-
-namespace laser_odometry {
-
-/**
- * @brief updateKf
- */
-template <typename Msg>
-void LaserOdometryBase::updateKf(Msg&& msg)
-{
-  updateKfMsg(std::forward<Msg>(msg));
-  updateKfTransform();
-}
-
-template <typename Msg>
-inline LaserOdometryBase::ProcessReport
-LaserOdometryBase::process(Msg&& msg)
-{
-  if (msg == nullptr)
-  {
-    ROS_WARN("Laser odometry process function received a nullptr input message!");
-    return ProcessReport::ErrorReport();
-  }
-
-  ros::WallTime start = ros::WallTime::now();
-
-  has_new_kf_   = false;
-  current_time_ = msg->header.stamp;
-
-  // first message
-  if (!initialized_)
-  {
-    initialized_ = initialize(std::forward<Msg>(msg));
-
-    initializeFrames();
-
-    ROS_INFO_STREAM_COND(initialized_, "LaserOdometry Initialized!");
-
-    return ProcessReport{true, true};
-  }
-
-  preProcessing();
-
-  // the predicted change of the laser's position, in the laser frame
-  const Transform increment_prior_in_laser = getIncrementPriorInLaserFrame();
-
-  // The actual computation
-  const bool processed = processImpl(std::forward<Msg>(msg), increment_prior_in_laser);
-
-  assertIncrement();
-  assertIncrementCovariance();
-
-  posePlusIncrement(processed);
-
-  has_new_kf_ = isKeyFrame(increment_in_base_);
-
-  if (has_new_kf_)
-  {
-    // generate a keyframe
-    updateKf(std::forward<Msg>(msg));
-
-    isKeyFrame();
-  }
-  else
-    isNotKeyFrame();
-
-  postProcessing();
-
-  execution_time_ = ros::WallTime::now() - start;
-
-  return ProcessReport{processed, has_new_kf_};
-}
-
-template <typename Msg, typename PoseMsgT, typename IncrementMsgT>
-LaserOdometryBase::ProcessReport
-LaserOdometryBase::process(Msg&& msg,
-                           PoseMsgT&& pose_msg,
-                           IncrementMsgT&& pose_increment_msg)
-{
-  const auto report = process(std::forward<Msg>(msg));
-
-  fillMsgs(std::forward<PoseMsgT>(pose_msg),
-           std::forward<IncrementMsgT>(pose_increment_msg));
-
-  return report;
-}
-
-} /* namespace laser_odometry */
+#include <laser_odometry_core/laser_odometry_base.hpp>
 
 #endif /* _LASER_ODOMETRY_CORE_LASER_ODOMETRY_BASE_H_ */

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.hpp
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.hpp
@@ -1,0 +1,99 @@
+#ifndef _LASER_ODOMETRY_CORE_LASER_ODOMETRY_BASE_HPP_
+#define _LASER_ODOMETRY_CORE_LASER_ODOMETRY_BASE_HPP_
+
+// Un-comment for IDE highlights
+//#include <laser_odometry_core/laser_odometry_base.h>
+
+namespace laser_odometry {
+
+template <typename Msg>
+void LaserOdometryBase::updateKf(Msg&& msg)
+{
+  updateKfMsg(std::forward<Msg>(msg));
+  updateKfTransform();
+}
+
+template <typename PoseMsgT, typename IncrementMsgT>
+void LaserOdometryBase::fillMsgs(PoseMsgT&& pose_msg_ptr,
+                                 IncrementMsgT&& increment_msg_ptr)
+{
+  fillMsg(std::forward<PoseMsgT>(pose_msg_ptr));
+  fillIncrementMsg(std::forward<IncrementMsgT>(increment_msg_ptr));
+}
+
+template <typename Msg>
+inline LaserOdometryBase::ProcessReport
+LaserOdometryBase::process(Msg&& msg)
+{
+  if (msg == nullptr)
+  {
+    ROS_WARN("Laser odometry process function received a nullptr input message!");
+    return ProcessReport::ErrorReport();
+  }
+
+  ros::WallTime start = ros::WallTime::now();
+
+  has_new_kf_   = false;
+  current_time_ = msg->header.stamp;
+
+  // first message
+  if (!initialized_)
+  {
+    initialized_ = initialize(std::forward<Msg>(msg));
+
+    initializeFrames();
+
+    ROS_INFO_STREAM_COND(initialized_, "LaserOdometry Initialized!");
+
+    return ProcessReport{true, true};
+  }
+
+  preProcessing();
+
+  // the predicted change of the laser's position, in the laser frame
+  const Transform increment_prior_in_laser = getIncrementPriorInLaserFrame();
+
+  // The actual computation
+  const bool processed = processImpl(std::forward<Msg>(msg), increment_prior_in_laser);
+
+  assertIncrement();
+  assertIncrementCovariance();
+
+  posePlusIncrement(processed);
+
+  has_new_kf_ = isKeyFrame(increment_in_base_);
+
+  if (has_new_kf_)
+  {
+    // generate a keyframe
+    updateKf(std::forward<Msg>(msg));
+
+    isKeyFrame();
+  }
+  else
+    isNotKeyFrame();
+
+  postProcessing();
+
+  execution_time_ = ros::WallTime::now() - start;
+
+  return ProcessReport{processed, has_new_kf_};
+}
+
+template <typename Msg, typename PoseMsgT, typename IncrementMsgT>
+LaserOdometryBase::ProcessReport
+LaserOdometryBase::process(Msg&& msg,
+                           PoseMsgT&& pose_msg,
+                           IncrementMsgT&& pose_increment_msg)
+{
+  const auto report = process(std::forward<Msg>(msg));
+
+  fillMsgs(std::forward<PoseMsgT>(pose_msg),
+           std::forward<IncrementMsgT>(pose_increment_msg));
+
+  return report;
+}
+
+} /* namespace laser_odometry */
+
+#endif /* _LASER_ODOMETRY_CORE_LASER_ODOMETRY_BASE_HPP_ */

--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_utils.h
@@ -5,42 +5,13 @@
 
 #include <Eigen/Eigenvalues>
 
-#include <tf/tf.h>
-#include <tf/transform_listener.h>
-
 namespace laser_odometry
 {
 namespace utils
 {
 
 void tfFromXYTheta(const double x, const double y,
-                   const double theta, tf::Transform& t);
-
-void tfFromXYTheta(const double x, const double y,
                    const double theta, Transform& t);
-
-bool getTf(const std::string& source_frame,
-           const std::string& target_frame,
-           tf::StampedTransform& tf,
-           const ros::Time& t = ros::Time(0),
-           const ros::Duration& d = ros::Duration(1.5));
-
-bool getTf(const std::string& source_frame,
-           const std::string& target_frame,
-           tf::Transform& tf,
-           const ros::Time& t = ros::Time(0),
-           const ros::Duration& d = ros::Duration(1.5));
-
-bool getTf(const tf::tfMessagePtr tf_msg,
-           const std::string& source_frame,
-           const std::string& target_frame,
-           tf::Transform& tf);
-
-bool isIdentity(const tf::Transform& tf, const double eps = 1e-8);
-
-std::string format(const tf::Transform& tf);
-
-void print(const tf::Transform& tf, const std::string& h = "");
 
 template <typename T>
 bool all_positive(const std::vector<T> vec)

--- a/laser_odometry_core/src/laser_odometry_base.cpp
+++ b/laser_odometry_core/src/laser_odometry_base.cpp
@@ -91,20 +91,25 @@ void LaserOdometryBase::fillIncrementMsg<TransformWithCovariancePtr&>(TransformW
   msg_ptr->covariance_ = increment_covariance_in_base_;
 }
 
+} /* namespace laser_odometry */
+
+namespace laser_odometry
+{
+
 // Class functions definition
 
 bool LaserOdometryBase::configure()
 {
   hardReset();
 
-  private_nh_.param("laser_frame",      laser_frame_,      laser_frame_);
-  private_nh_.param("base_frame",       base_frame_,       base_frame_);
-  private_nh_.param("odom_frame",       fixed_frame_,      fixed_frame_);
-  private_nh_.param("laser_odom_frame", laser_odom_frame_, laser_odom_frame_);
+  utils::getParam(private_nh_, "laser_frame",      laser_frame_,      laser_frame_,      true);
+  utils::getParam(private_nh_, "base_frame",       base_frame_,       base_frame_,       true);
+  utils::getParam(private_nh_, "fixed_frame",      fixed_frame_,      fixed_frame_,      true);
+  utils::getParam(private_nh_, "laser_odom_frame", laser_odom_frame_, laser_odom_frame_, true);
 
   // Default covariance diag :
-  std::vector<Scalar> default_covariance(default_cov_diag_);
-  private_nh_.param("covariance_diag", default_covariance, default_covariance);
+  std::vector<Scalar> default_covariance;
+  utils::getParam(private_nh_, "covariance_diag", default_covariance, default_cov_diag_, true);
 
   if (utils::all_positive(default_covariance))
   {

--- a/laser_odometry_core/src/laser_odometry_utils.cpp
+++ b/laser_odometry_core/src/laser_odometry_utils.cpp
@@ -5,12 +5,6 @@ namespace laser_odometry
 namespace utils
 {
 
-void tfFromXYTheta(const double x, const double y, const double theta, tf::Transform& t)
-{
-  t = tf::Transform(tf::createQuaternionFromYaw(theta),
-                    {x, y, 0});
-}
-
 void tfFromXYTheta(const double x, const double y, const double theta, Transform& t)
 {
   Eigen::AngleAxis<Scalar> rollAngle(0,    Eigen::Vector3d::UnitX());
@@ -21,107 +15,6 @@ void tfFromXYTheta(const double x, const double y, const double theta, Transform
 
   t = q;
   t.translation() = Eigen::Matrix<Scalar, 3, 1>(x, y, 0);
-}
-
-bool getTf(const std::string& source_frame,
-           const std::string& target_frame,
-           tf::StampedTransform& tf,
-           const ros::Time& t,
-           const ros::Duration& d)
-{
-  tf::TransformListener tf_listener;
-  tf::StampedTransform tf_tmp;
-
-  std::string error;
-  if (tf_listener.waitForTransform(target_frame, source_frame, t, d, ros::Duration(0.01), &error))
-  {
-    try
-    {
-      tf_listener.lookupTransform (
-        target_frame, source_frame, t, tf_tmp);
-    }
-    catch (tf::TransformException ex)
-    {
-      ROS_WARN("Could not get transform from %s to %s at %f after %f :\n %s",
-               source_frame.c_str(), target_frame.c_str(),
-               t.toSec(), d.toSec(), ex.what());
-
-      return false;
-    }
-  }
-  else
-  {
-    ROS_WARN("Could not find transform from %s to %s at %f after %f :\n %s",
-             source_frame.c_str(), target_frame.c_str(),
-             t.toSec(), d.toSec(), error.c_str());
-    return false;
-  }
-
-  tf = tf_tmp;
-  return true;
-}
-
-bool getTf(const std::string& source_frame,
-           const std::string& target_frame,
-           tf::Transform& tf,
-           const ros::Time& t,
-           const ros::Duration& d)
-{
-  tf::StampedTransform stamped_tf;
-
-  bool ok = getTf(source_frame, target_frame, stamped_tf, t, d);
-
-  if (ok) tf = stamped_tf;
-
-  return ok;
-}
-
-bool getTf(const tf::tfMessagePtr tf_msg,
-           const std::string& source_frame,
-           const std::string& target_frame,
-           tf::Transform& tf)
-{
-  for (const geometry_msgs::TransformStamped& tft : tf_msg->transforms)
-  {
-    if (tft.header.frame_id.compare(source_frame) == 0)
-      if (tft.child_frame_id.compare(target_frame) == 0)
-      {
-        tf::transformMsgToTF(tft.transform, tf);
-        return true;
-      }
-  }
-
-  return false;
-}
-
-bool isIdentity(const tf::Transform& tf, const double eps)
-{
-  const tf::Vector3& o = tf.getOrigin();
-
-  if (o.x() > eps) return false;
-  if (o.y() > eps) return false;
-  if (o.z() > eps) return false;
-
-  if (tf.getRotation().angleShortestPath(
-        tf::Quaternion::getIdentity()) > eps) return false;
-
-  return true;
-}
-
-std::string format(const tf::Transform& tf)
-{
-  std::stringstream ss;
-
-  ss << tf.getOrigin().getX()
-     << " " << tf.getOrigin().getY()
-     << " " << tf::getYaw(tf.getRotation());
-
-  return ss.str();
-}
-
-void print(const tf::Transform& tf, const std::string& h)
-{
-  std::cout << h << format(tf) << std::endl;
 }
 
 template <>


### PR DESCRIPTION
Comes on top of #18.

Basically add a couple templates to have a single `process(*)` definition, easier to maintain.

But also :  
- Custom `getParam` for moar verbosity
- `LaserOdometryBase` non-copyable/movable.
- Some cleaning.