### PR TITLE
massive renaming and frame fixing

### DIFF
--- a/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.hpp
+++ b/laser_odometry_core/include/laser_odometry_core/laser_odometry_base.hpp
@@ -61,7 +61,7 @@ LaserOdometryBase::process(Msg&& msg)
 
   posePlusIncrement(processed);
 
-  has_new_kf_ = isKeyFrame(increment_in_base_);
+  has_new_kf_ = isKeyFrame(getIncrementSinceKeyFrame());
 
   if (has_new_kf_)
   {


### PR DESCRIPTION
- massive renaming for clearer frame composition
- update final integration only on keyframe (odom in world)
- remove confusing `getKeyFrameEstimatedPose` 
- add `getIncrementSinceKeyFrame`
- pre-allocate some variables